### PR TITLE
CLOSES #2: Disables cloud-init module cc_locale.

### DIFF
--- a/CentOS-7-Minimal-Cloud-Init-virtualbox.json
+++ b/CentOS-7-Minimal-Cloud-Init-virtualbox.json
@@ -182,6 +182,7 @@
       "scripts": [
         "scripts/install/tuned-virtual-guest.sh",
         "scripts/install/cloud-init.sh",
+        "scripts/cloud-init/disable-locale-module.sh",
         "scripts/common/ifcfg-name-to-device.sh",
         "scripts/common/sshd-config-non-root-key-auth.sh",
         "scripts/common/sudoers-default-not-requiretty.sh",

--- a/scripts/cloud-init/disable-locale-module.sh
+++ b/scripts/cloud-init/disable-locale-module.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+/bin/echo '--> Disabling cloud-init locale module.'
+/bin/sed -i \
+  -e 's~^\([ ]*\)\(- locale\)$~\1#\2~' \
+  /etc/cloud/cloud.cfg


### PR DESCRIPTION
Resolves #2 
- Disables cloud-init module cc_locale which cannot be used with locale specific builds.
