### PR TITLE
CLOSES #5: Adds re-ordered list of cloud-init datasources positioning

### DIFF
--- a/CentOS-7-Minimal-Cloud-Init-virtualbox.json
+++ b/CentOS-7-Minimal-Cloud-Init-virtualbox.json
@@ -183,6 +183,7 @@
         "scripts/install/tuned-virtual-guest.sh",
         "scripts/install/cloud-init.sh",
         "scripts/cloud-init/disable-locale-module.sh",
+        "scripts/cloud-init/add-datasource-list.sh",
         "scripts/common/ifcfg-name-to-device.sh",
         "scripts/common/sshd-config-non-root-key-auth.sh",
         "scripts/common/sudoers-default-not-requiretty.sh",

--- a/scripts/cloud-init/add-datasource-list.sh
+++ b/scripts/cloud-init/add-datasource-list.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+/bin/echo '--> Adding cloud-init datasources_list.'
+/usr/bin/tee \
+  /etc/cloud/cloud.cfg.d/10_datasource_list.cfg \
+  1> /dev/null \
+  <<-EOF
+datasource_list: [
+  NoCloud,
+  ConfigDrive,
+  OpenNebula,
+  Azure,
+  AltCloud,
+  OVF,
+  MAAS,
+  GCE,
+  CloudStack,
+  OpenStack,
+  Ec2,
+  CloudSigma,
+  SmartOS,
+  None,
+]
+EOF

--- a/scripts/cloud-init/add-datasource-settings.sh
+++ b/scripts/cloud-init/add-datasource-settings.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+/bin/echo '--> Adding cloud-init datasource settings.'
+/usr/bin/tee \
+  /etc/cloud/cloud.cfg.d/10_datasource.cfg \
+  1> /dev/null \
+  <<-EOF
+datasource: 
+   Ec2: 
+     timeout: 10
+     max_wait: 60
+EOF


### PR DESCRIPTION
Resolves #5 
- Adds re-ordered list of cloud-init datasources. Positioning local-link based services after host route types (CloudStack). This allows a simple metadata service to be hosted from the VirtualBox host and prevents having to wait for the 120 second default timeout defined for the Ec2 datasource.
- Adds an example script to allow the Ec2 datasource to be configured with a reduced timeout; it's not included in the template unless a need arises.
