### PR TITLE
CLOSES #43: Correct kickstart filename case

### DIFF
--- a/CentOS-7-Minimal-AMI-virtualbox.json
+++ b/CentOS-7-Minimal-AMI-virtualbox.json
@@ -40,7 +40,7 @@
       "name": "{{user `build_name`}}",
       "boot_command": [
         "<esc><wait>",
-        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/CentOS-7-minimal.cfg",
+        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/centos-7-minimal.cfg",
         " BOOT_TIMEOUT={{user `guest_boot_timeout`}}",
         " BOOTLOADER_APPEND=\"{{user `guest_bootloader_append`}}\"",
         " BOOTLOADER_THEME=details",

--- a/CentOS-7-Minimal-Cloud-Init-virtualbox.json
+++ b/CentOS-7-Minimal-Cloud-Init-virtualbox.json
@@ -41,7 +41,7 @@
       "name": "{{user `build_name`}}",
       "boot_command": [
         "<esc><wait>",
-        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/CentOS-7-minimal.cfg",
+        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/centos-7-minimal.cfg",
         " BOOT_TIMEOUT={{user `guest_boot_timeout`}}",
         " BOOTLOADER_APPEND=\"{{user `guest_bootloader_append`}}\"",
         " BOOTLOADER_THEME=details",

--- a/CentOS-7-Minimal-virtualbox.json
+++ b/CentOS-7-Minimal-virtualbox.json
@@ -41,7 +41,7 @@
       "name": "{{user `build_name`}}",
       "boot_command": [
         "<esc><wait>",
-        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/CentOS-7-minimal.cfg",
+        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/centos-7-minimal.cfg",
         " BOOT_TIMEOUT={{user `guest_boot_timeout`}}",
         " BOOTLOADER_APPEND=\"{{user `guest_bootloader_append`}}\"",
         " BOOTLOADER_THEME=details",


### PR DESCRIPTION
Changed the kickstart filename to lower case (CentOS to centos) to match the filename in the http folder.

Prior to this change, the boot loader would complain about a 404 when attempting to load the kickstart file.