### PR TITLE
Release changes for 1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vagrant/
-builds/
-isos/
-output-*/
+/builds/
+/isos/
+/packer_cache/
+/output-*/

--- a/AWS_VM_IMPORT.md
+++ b/AWS_VM_IMPORT.md
@@ -53,13 +53,15 @@ Import the image from the S3 bucket `{{bucket_name}}`.
 
 ```
 $ aws ec2 import-image \
+  --region eu-west-1 \
   --cli-input-json '{ "LicenseType": "BYOL", "Description": "jdeathe/CentOS-7.4.1708-x86_64-Minimal-AMI-en_US", "DiskContainers": [ { "Description": "jdeathe/CentOS-7.4.1708-x86_64-Minimal-AMI-en_US", "Format": "ova", "UserBucket": { "S3Bucket": "{{bucket_name}}", "S3Key" : "CentOS-7.4.1708-x86_64-Minimal-AMI-en_US.ova" } } ]}'
 ```
 
 Check progress
 
 ```
-$ aws ec2 describe-import-image-tasks
+$ aws ec2 describe-import-image-tasks \
+  --region eu-west-1
 ```
 
 If you need to cancel the import:
@@ -94,6 +96,7 @@ Deregister the intermediate image that was created by the import process.
 
 ```
 $ aws ec2 deregister-image \
+  --region eu-west-1 \
   --image-id {{ImageId}}
 ```
 
@@ -101,6 +104,7 @@ Identify SpanshotId. i.e. With a Description starting "Created by AWS-VMImport s
 
 ```
 $ aws ec2 describe-snapshots \
+  --region eu-west-1 \
   --owner-ids self
 ```
 
@@ -108,6 +112,7 @@ Remove snapshot created by the import process.
 
 ```
 $ aws ec2 delete-snapshot \
+  --region eu-west-1 \
   --snapshot-id {{SnapshotId}}
 ```
 

--- a/CentOS-7-Minimal-AMI-virtualbox.json
+++ b/CentOS-7-Minimal-AMI-virtualbox.json
@@ -40,7 +40,7 @@
       "name": "{{user `build_name`}}",
       "boot_command": [
         "<esc><wait>",
-        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/CentOS-7-minimal.cfg",
+        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/centos-7-minimal.cfg",
         " BOOT_TIMEOUT={{user `guest_boot_timeout`}}",
         " BOOTLOADER_APPEND=\"{{user `guest_bootloader_append`}}\"",
         " BOOTLOADER_THEME=details",

--- a/CentOS-7-Minimal-AMI-virtualbox.json
+++ b/CentOS-7-Minimal-AMI-virtualbox.json
@@ -1,11 +1,11 @@
 {
   "variables": {
     "build_export_format": "ova",
-    "build_iso_checksum": "71a7aa147877b413497cdff5b1e0aa5bc0c9484f",
+    "build_iso_checksum": "13675c6f74880e7ff3481b91bdaf925ce81bda8f",
     "build_iso_checksum_type": "sha1",
-    "build_iso_filename": "CentOS-7-x86_64-Minimal-1708.iso",
+    "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
     "build_iso_target_path": "isos/x86_64",
-    "build_name": "CentOS-7.4.1708-x86_64-Minimal-AMI-en_US",
+    "build_name": "CentOS-7.5.1804-x86_64-Minimal-AMI-en_US",
     "build_output_directory": "builds",
     "guest_boot_timeout": "0",
     "guest_bootloader_append": "net.ifnames=0 biosdevname=0",
@@ -18,9 +18,9 @@
     "guest_lv_root_mkfsoptions": "-i 4096",
     "guest_lv_root_size": "1024",
     "guest_lv_swap_size": "0",
-    "guest_name": "CentOS-7.4.1708-x86_64-Minimal-AMI-en_US",
+    "guest_name": "CentOS-7.5.1804-x86_64-Minimal-AMI-en_US",
     "guest_partition_boot_fstype": "ext4",
-    "guest_partition_boot_size": "250",
+    "guest_partition_boot_size": "1024",
     "guest_memory": "1024",
     "guest_selinux": "permissive",
     "guest_timezone": "Etc/UTC",
@@ -92,8 +92,7 @@
         ["modifyvm","{{.Name}}","--clipboard","disabled"],
         ["modifyvm","{{.Name}}","--draganddrop","disabled"],
         ["modifyvm","{{.Name}}","--usb","off"],
-        ["modifyvm","{{.Name}}","--audio","none"],
-        ["modifyvm","{{.Name}}","--videocap","off"]
+        ["modifyvm","{{.Name}}","--audio","none"]
       ],
       "vboxmanage_post": [
         ["modifyvm","{{.Name}}","--cpus","{{user `guest_cpus`}}"],

--- a/CentOS-7-Minimal-Cloud-Init-virtualbox.json
+++ b/CentOS-7-Minimal-Cloud-Init-virtualbox.json
@@ -1,11 +1,11 @@
 {
   "variables": {
     "build_export_format": "ovf",
-    "build_iso_checksum": "71a7aa147877b413497cdff5b1e0aa5bc0c9484f",
+    "build_iso_checksum": "13675c6f74880e7ff3481b91bdaf925ce81bda8f",
     "build_iso_checksum_type": "sha1",
-    "build_iso_filename": "CentOS-7-x86_64-Minimal-1708.iso",
+    "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
     "build_iso_target_path": "isos/x86_64",
-    "build_name": "CentOS-7.4.1708-x86_64-Minimal-Cloud-Init-en_US",
+    "build_name": "CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US",
     "build_output_directory": "builds",
     "guest_boot_timeout": "0",
     "guest_bootloader_append": "net.ifnames=0 biosdevname=0",
@@ -18,10 +18,10 @@
     "guest_lv_root_mkfsoptions": "-i 4096",
     "guest_lv_root_size": "1024",
     "guest_lv_swap_size": "4096",
-    "guest_name": "CentOS-7.4.1708-x86_64-Minimal-Cloud-Init-en_US",
+    "guest_name": "CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US",
     "guest_partition_boot_fstype": "ext4",
-    "guest_partition_boot_size": "250",
-    "guest_memory": "512",
+    "guest_partition_boot_size": "1024",
+    "guest_memory": "1024",
     "guest_selinux": "permissive",
     "guest_timezone": "Etc/UTC",
     "guest_vram": "16",
@@ -93,8 +93,7 @@
         ["modifyvm","{{.Name}}","--clipboard","disabled"],
         ["modifyvm","{{.Name}}","--draganddrop","disabled"],
         ["modifyvm","{{.Name}}","--usb","off"],
-        ["modifyvm","{{.Name}}","--audio","none"],
-        ["modifyvm","{{.Name}}","--videocap","off"]
+        ["modifyvm","{{.Name}}","--audio","none"]
       ],
       "vboxmanage_post": [
         ["modifyvm","{{.Name}}","--cpus","{{user `guest_cpus`}}"],

--- a/CentOS-7-Minimal-Cloud-Init-virtualbox.json
+++ b/CentOS-7-Minimal-Cloud-Init-virtualbox.json
@@ -41,7 +41,7 @@
       "name": "{{user `build_name`}}",
       "boot_command": [
         "<esc><wait>",
-        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/CentOS-7-minimal.cfg",
+        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/centos-7-minimal.cfg",
         " BOOT_TIMEOUT={{user `guest_boot_timeout`}}",
         " BOOTLOADER_APPEND=\"{{user `guest_bootloader_append`}}\"",
         " BOOTLOADER_THEME=details",

--- a/CentOS-7-Minimal-virtualbox.json
+++ b/CentOS-7-Minimal-virtualbox.json
@@ -1,11 +1,11 @@
 {
   "variables": {
     "build_export_format": "ovf",
-    "build_iso_checksum": "71a7aa147877b413497cdff5b1e0aa5bc0c9484f",
+    "build_iso_checksum": "13675c6f74880e7ff3481b91bdaf925ce81bda8f",
     "build_iso_checksum_type": "sha1",
-    "build_iso_filename": "CentOS-7-x86_64-Minimal-1708.iso",
+    "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
     "build_iso_target_path": "isos/x86_64",
-    "build_name": "CentOS-7.4.1708-x86_64-Minimal-en_US",
+    "build_name": "CentOS-7.5.1804-x86_64-Minimal-en_US",
     "build_output_directory": "builds",
     "guest_boot_timeout": "0",
     "guest_bootloader_append": "net.ifnames=0 biosdevname=0",
@@ -18,10 +18,10 @@
     "guest_lv_root_mkfsoptions": "-i 4096",
     "guest_lv_root_size": "1024",
     "guest_lv_swap_size": "4096",
-    "guest_name": "CentOS-7.4.1708-x86_64-Minimal-en_US",
+    "guest_name": "CentOS-7.5.1804-x86_64-Minimal-en_US",
     "guest_partition_boot_fstype": "ext4",
     "guest_partition_boot_size": "1024",
-    "guest_memory": "512",
+    "guest_memory": "1024",
     "guest_selinux": "permissive",
     "guest_timezone": "Etc/UTC",
     "guest_vram": "16",
@@ -93,8 +93,7 @@
         ["modifyvm","{{.Name}}","--clipboard","disabled"],
         ["modifyvm","{{.Name}}","--draganddrop","disabled"],
         ["modifyvm","{{.Name}}","--usb","off"],
-        ["modifyvm","{{.Name}}","--audio","none"],
-        ["modifyvm","{{.Name}}","--videocap","off"]
+        ["modifyvm","{{.Name}}","--audio","none"]
       ],
       "vboxmanage_post": [
         ["modifyvm","{{.Name}}","--cpus","{{user `guest_cpus`}}"],

--- a/CentOS-7-Minimal-virtualbox.json
+++ b/CentOS-7-Minimal-virtualbox.json
@@ -41,7 +41,7 @@
       "name": "{{user `build_name`}}",
       "boot_command": [
         "<esc><wait>",
-        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/CentOS-7-minimal.cfg",
+        "linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/centos-7-minimal.cfg",
         " BOOT_TIMEOUT={{user `guest_boot_timeout`}}",
         " BOOTLOADER_APPEND=\"{{user `guest_bootloader_append`}}\"",
         " BOOTLOADER_THEME=details",

--- a/CentOS-7.5.1804-x86_64-Minimal-AMI-en_US.json
+++ b/CentOS-7.5.1804-x86_64-Minimal-AMI-en_US.json
@@ -1,0 +1,16 @@
+{
+  "build_iso_checksum": "13675c6f74880e7ff3481b91bdaf925ce81bda8f",
+  "build_iso_checksum_type": "sha1",
+  "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
+  "build_iso_target_path": "isos/x86_64",
+  "build_name": "CentOS-7.5.1804-x86_64-Minimal-AMI-en_US",
+  "guest_hard_disk_size": "4096",
+  "guest_keyboard": "us",
+  "guest_language": "en_US.UTF-8",
+  "guest_lv_swap_size": "0",
+  "guest_name": "CentOS-7.5.1804-x86_64-Minimal-AMI-en_US",
+  "guest_partition_boot_size": "1024",
+  "guest_memory": "1024",
+  "guest_selinux": "permissive",
+  "guest_vg_root_reserved_space": "0"
+}

--- a/CentOS-7.5.1804-x86_64-Minimal-AMI-en_US.json
+++ b/CentOS-7.5.1804-x86_64-Minimal-AMI-en_US.json
@@ -4,6 +4,7 @@
   "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
   "build_iso_target_path": "isos/x86_64",
   "build_name": "CentOS-7.5.1804-x86_64-Minimal-AMI-en_US",
+  "guest_bootloader_append": "net.ifnames=0 biosdevname=0 elevator=noop",
   "guest_hard_disk_size": "4096",
   "guest_keyboard": "us",
   "guest_language": "en_US.UTF-8",

--- a/CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US.json
+++ b/CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US.json
@@ -1,0 +1,16 @@
+{
+  "build_iso_checksum": "13675c6f74880e7ff3481b91bdaf925ce81bda8f",
+  "build_iso_checksum_type": "sha1",
+  "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
+  "build_iso_target_path": "isos/x86_64",
+  "build_name": "CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US",
+  "guest_hard_disk_size": "40960",
+  "guest_keyboard": "us",
+  "guest_language": "en_US.UTF-8",
+  "guest_lv_swap_size": "4096",
+  "guest_name": "CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US",
+  "guest_partition_boot_size": "1024",
+  "guest_memory": "1024",
+  "guest_selinux": "permissive",
+  "guest_vg_root_reserved_space": "0"
+}

--- a/CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US.json
+++ b/CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US.json
@@ -4,6 +4,7 @@
   "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
   "build_iso_target_path": "isos/x86_64",
   "build_name": "CentOS-7.5.1804-x86_64-Minimal-Cloud-Init-en_US",
+  "guest_bootloader_append": "net.ifnames=0 biosdevname=0 elevator=noop",
   "guest_hard_disk_size": "40960",
   "guest_keyboard": "us",
   "guest_language": "en_US.UTF-8",

--- a/CentOS-7.5.1804-x86_64-Minimal-en_US.json
+++ b/CentOS-7.5.1804-x86_64-Minimal-en_US.json
@@ -4,6 +4,7 @@
   "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
   "build_iso_target_path": "isos/x86_64",
   "build_name": "CentOS-7.5.1804-x86_64-Minimal-en_US",
+  "guest_bootloader_append": "net.ifnames=0 biosdevname=0 elevator=noop",
   "guest_hard_disk_size": "40960",
   "guest_keyboard": "us",
   "guest_language": "en_US.UTF-8",

--- a/CentOS-7.5.1804-x86_64-Minimal-en_US.json
+++ b/CentOS-7.5.1804-x86_64-Minimal-en_US.json
@@ -1,0 +1,16 @@
+{
+  "build_iso_checksum": "13675c6f74880e7ff3481b91bdaf925ce81bda8f",
+  "build_iso_checksum_type": "sha1",
+  "build_iso_filename": "CentOS-7-x86_64-Minimal-1804.iso",
+  "build_iso_target_path": "isos/x86_64",
+  "build_name": "CentOS-7.5.1804-x86_64-Minimal-en_US",
+  "guest_hard_disk_size": "40960",
+  "guest_keyboard": "us",
+  "guest_language": "en_US.UTF-8",
+  "guest_lv_swap_size": "4096",
+  "guest_name": "CentOS-7.5.1804-x86_64-Minimal-en_US",
+  "guest_partition_boot_size": "1024",
+  "guest_memory": "1024",
+  "guest_selinux": "permissive",
+  "guest_vg_root_reserved_space": "0"
+}

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ Variables (default value):
                               - Minimal-AMI
                               - Minimal-Cloud-Init
   - BOX_VERSION_RELEASE     The CentOS-7 Minor Release number. Note: A
-    (7.4.1708)              corresponding template is required.
+    (7.5.1804)              corresponding template is required.
 
 endef
 
@@ -47,7 +47,7 @@ BOX_DEBUG ?= false
 BOX_LANG ?= en_US
 BOX_OUTPUT_PATH ?= ./builds
 BOX_VARIANT ?= Minimal
-BOX_VERSION_RELEASE ?= 7.4.1708
+BOX_VERSION_RELEASE ?= 7.5.1804
 
 # UI constants
 COLOUR_NEGATIVE := \033[1;31m

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 This provides the configuration and Makefile to build a [Vagrant](https://www.vagrantup.com) minimal base box using [Packer](https://www.packer.io). The base box is intended for server (terminal) use only so is restricted to a single locale (with `en_US` being the default) which allows for a smaller box size.
 
-There are templates provided for `CentOS-7.2.1511`, `CentOS-7.3.1611`, and `CentOS-7.4.1708` with `x86_64` architecture. There is currently no requirement to support older minor release versions or alternative architectures but they could be added if necessary.
+There are templates provided for the following with `x86_64` architecture:
+- CentOS-7.5.1804
+- CentOS-7.4.1708
+- CentOS-7.3.1611
+- CentOS-7.2.1511
+
+There is currently no requirement to support older minor release versions or alternative architectures but they could be added if necessary.
 
 ## Usage Instructions
 
@@ -12,19 +18,19 @@ The build environment required is Mac OSX or GNU Linux.
 
 To build the box file you will need the following installed:
 
-- [VirtualBox](https://www.virtualbox.org) (5.1.28)
-- [Vagrant](https://www.vagrantup.com) (2.0.0)
-- [Packer](https://www.packer.io) (1.1.0)
+- [VirtualBox](https://www.virtualbox.org) (6.0.10)
+- [Vagrant](https://www.vagrantup.com) (2.2.5)
+- [Packer](https://www.packer.io) (1.4.3)
 
 ### Build
 
-To build the latest `7.4.1708`, `x86_64` base box run `make` or `make build`.
+To build the latest, `x86_64` base box run `make` or `make build`.
 
 ```
 $ make
 ```
 
-To build the `7.2.1511` release version, use the `BOX_VERSION_RELEASE` environment variable.
+To build a specific release version, use the `BOX_VERSION_RELEASE` variable.
 
 ```
 $ BOX_VERSION_RELEASE=7.2.1511 make

--- a/scripts/common/stop-and-truncate-logs.sh
+++ b/scripts/common/stop-and-truncate-logs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 /bin/echo '--> Stopping logging services.'
-/usr/bin/systemctl stop auditd.service
+/sbin/service auditd stop
 /usr/bin/systemctl stop rsyslog.service
 
 /bin/echo '--> Truncate log files.'


### PR DESCRIPTION
- Adds 7.5.1804 builds.
- Default guest memory increased to 1024M from 512M for both Minimal and Minimal-Cloud-Init variants.
- Tested against the following requirements:
  - [VirtualBox](https://www.virtualbox.org) (6.0.10)
  - [Vagrant](https://www.vagrantup.com) (2.2.5)
  - [Packer](https://www.packer.io) (1.4.3)