### PR TITLE
CLOSES #53: Adds support for 7.7.1908.

### DIFF
--- a/CentOS-7-Minimal-AMI-virtualbox.json
+++ b/CentOS-7-Minimal-AMI-virtualbox.json
@@ -1,11 +1,11 @@
 {
   "variables": {
     "build_export_format": "ova",
-    "build_iso_checksum": "38d5d51d9d100fd73df031ffd6bd8b1297ce24660dc8c13a3b8b4534a4bd291c",
+    "build_iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
     "build_iso_checksum_type": "sha256",
-    "build_iso_filename": "CentOS-7-x86_64-Minimal-1810.iso",
+    "build_iso_filename": "CentOS-7-x86_64-Minimal-1908.iso",
     "build_iso_target_path": "isos/x86_64",
-    "build_name": "CentOS-7.6.1810-x86_64-Minimal-AMI-en_US",
+    "build_name": "CentOS-7.7.1908-x86_64-Minimal-AMI-en_US",
     "build_output_directory": "builds",
     "guest_boot_timeout": "0",
     "guest_bootloader_append": "net.ifnames=0 biosdevname=0",
@@ -18,7 +18,7 @@
     "guest_lv_root_mkfsoptions": "-i 4096",
     "guest_lv_root_size": "1024",
     "guest_lv_swap_size": "0",
-    "guest_name": "CentOS-7.6.1810-x86_64-Minimal-AMI-en_US",
+    "guest_name": "CentOS-7.7.1908-x86_64-Minimal-AMI-en_US",
     "guest_partition_boot_fstype": "ext4",
     "guest_partition_boot_size": "1024",
     "guest_memory": "1024",

--- a/CentOS-7-Minimal-Cloud-Init-virtualbox.json
+++ b/CentOS-7-Minimal-Cloud-Init-virtualbox.json
@@ -1,11 +1,11 @@
 {
   "variables": {
     "build_export_format": "ovf",
-    "build_iso_checksum": "38d5d51d9d100fd73df031ffd6bd8b1297ce24660dc8c13a3b8b4534a4bd291c",
+    "build_iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
     "build_iso_checksum_type": "sha256",
-    "build_iso_filename": "CentOS-7-x86_64-Minimal-1810.iso",
+    "build_iso_filename": "CentOS-7-x86_64-Minimal-1908.iso",
     "build_iso_target_path": "isos/x86_64",
-    "build_name": "CentOS-7.6.1810-x86_64-Minimal-Cloud-Init-en_US",
+    "build_name": "CentOS-7.7.1908-x86_64-Minimal-Cloud-Init-en_US",
     "build_output_directory": "builds",
     "guest_boot_timeout": "0",
     "guest_bootloader_append": "net.ifnames=0 biosdevname=0",
@@ -18,7 +18,7 @@
     "guest_lv_root_mkfsoptions": "-i 4096",
     "guest_lv_root_size": "1024",
     "guest_lv_swap_size": "4096",
-    "guest_name": "CentOS-7.6.1810-x86_64-Minimal-Cloud-Init-en_US",
+    "guest_name": "CentOS-7.7.1908-x86_64-Minimal-Cloud-Init-en_US",
     "guest_partition_boot_fstype": "ext4",
     "guest_partition_boot_size": "1024",
     "guest_memory": "1024",

--- a/CentOS-7-Minimal-virtualbox.json
+++ b/CentOS-7-Minimal-virtualbox.json
@@ -1,11 +1,11 @@
 {
   "variables": {
     "build_export_format": "ovf",
-    "build_iso_checksum": "38d5d51d9d100fd73df031ffd6bd8b1297ce24660dc8c13a3b8b4534a4bd291c",
+    "build_iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
     "build_iso_checksum_type": "sha256",
-    "build_iso_filename": "CentOS-7-x86_64-Minimal-1810.iso",
+    "build_iso_filename": "CentOS-7-x86_64-Minimal-1908.iso",
     "build_iso_target_path": "isos/x86_64",
-    "build_name": "CentOS-7.6.1810-x86_64-Minimal-en_US",
+    "build_name": "CentOS-7.7.1908-x86_64-Minimal-en_US",
     "build_output_directory": "builds",
     "guest_boot_timeout": "0",
     "guest_bootloader_append": "net.ifnames=0 biosdevname=0",
@@ -18,7 +18,7 @@
     "guest_lv_root_mkfsoptions": "-i 4096",
     "guest_lv_root_size": "1024",
     "guest_lv_swap_size": "4096",
-    "guest_name": "CentOS-7.6.1810-x86_64-Minimal-en_US",
+    "guest_name": "CentOS-7.7.1908-x86_64-Minimal-en_US",
     "guest_partition_boot_fstype": "ext4",
     "guest_partition_boot_size": "1024",
     "guest_memory": "1024",

--- a/CentOS-7.7.1908-x86_64-Minimal-AMI-en_US.json
+++ b/CentOS-7.7.1908-x86_64-Minimal-AMI-en_US.json
@@ -1,0 +1,17 @@
+{
+  "build_iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
+  "build_iso_checksum_type": "sha256",
+  "build_iso_filename": "CentOS-7-x86_64-Minimal-1908.iso",
+  "build_iso_target_path": "isos/x86_64",
+  "build_name": "CentOS-7.7.1908-x86_64-Minimal-AMI-en_US",
+  "guest_bootloader_append": "net.ifnames=0 biosdevname=0 elevator=noop",
+  "guest_hard_disk_size": "4096",
+  "guest_keyboard": "us",
+  "guest_language": "en_US.UTF-8",
+  "guest_lv_swap_size": "0",
+  "guest_name": "CentOS-7.7.1908-x86_64-Minimal-AMI-en_US",
+  "guest_partition_boot_size": "1024",
+  "guest_memory": "1024",
+  "guest_selinux": "permissive",
+  "guest_vg_root_reserved_space": "0"
+}

--- a/CentOS-7.7.1908-x86_64-Minimal-Cloud-Init-en_US.json
+++ b/CentOS-7.7.1908-x86_64-Minimal-Cloud-Init-en_US.json
@@ -1,0 +1,17 @@
+{
+  "build_iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
+  "build_iso_checksum_type": "sha256",
+  "build_iso_filename": "CentOS-7-x86_64-Minimal-1908.iso",
+  "build_iso_target_path": "isos/x86_64",
+  "build_name": "CentOS-7.7.1908-x86_64-Minimal-Cloud-Init-en_US",
+  "guest_bootloader_append": "net.ifnames=0 biosdevname=0 elevator=noop",
+  "guest_hard_disk_size": "40960",
+  "guest_keyboard": "us",
+  "guest_language": "en_US.UTF-8",
+  "guest_lv_swap_size": "4096",
+  "guest_name": "CentOS-7.7.1908-x86_64-Minimal-Cloud-Init-en_US",
+  "guest_partition_boot_size": "1024",
+  "guest_memory": "1024",
+  "guest_selinux": "permissive",
+  "guest_vg_root_reserved_space": "0"
+}

--- a/CentOS-7.7.1908-x86_64-Minimal-en_US.json
+++ b/CentOS-7.7.1908-x86_64-Minimal-en_US.json
@@ -1,0 +1,17 @@
+{
+  "build_iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
+  "build_iso_checksum_type": "sha256",
+  "build_iso_filename": "CentOS-7-x86_64-Minimal-1908.iso",
+  "build_iso_target_path": "isos/x86_64",
+  "build_name": "CentOS-7.7.1908-x86_64-Minimal-en_US",
+  "guest_bootloader_append": "net.ifnames=0 biosdevname=0 elevator=noop",
+  "guest_hard_disk_size": "40960",
+  "guest_keyboard": "us",
+  "guest_language": "en_US.UTF-8",
+  "guest_lv_swap_size": "4096",
+  "guest_name": "CentOS-7.7.1908-x86_64-Minimal-en_US",
+  "guest_partition_boot_size": "1024",
+  "guest_memory": "1024",
+  "guest_selinux": "permissive",
+  "guest_vg_root_reserved_space": "0"
+}

--- a/Makefile
+++ b/Makefile
@@ -221,15 +221,21 @@ download-iso: _prerequisites _require-supported-architecture
 			mkdir -p ./isos/$(BOX_ARCH); \
 		fi; \
 		echo "$(PREFIX_STEP)Downloading ISO: http://mirrors.kernel.org/centos/$(BOX_VERSION_RELEASE)/isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME)"; \
-		$(curl) -LSo ./isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME) \
+		$(curl) \
+			--location \
+			--progress-bar \
+			--output ./isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME) \
 			http://mirrors.kernel.org/centos/$(BOX_VERSION_RELEASE)/isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME); \
-		if [[ $${?} -eq 0 ]]; then \
+		if [[ $${?} -ne 0 ]]; then \
 			rm -f ./isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME) &> /dev/null; \
 			echo "$(PREFIX_STEP)Download failed - trying vault: http://archive.kernel.org/centos-vault/$(BOX_VERSION_RELEASE)/isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME)"; \
-			$(curl) -LSo ./isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME) \
+			$(curl) \
+				--location \
+				--progress-bar \
+				--output ./isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME) \
 				http://archive.kernel.org/centos-vault/$(BOX_VERSION_RELEASE)/isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME); \
 		fi; \
-		if [[ $${?} -eq 0 ]]; then \
+		if [[ $${?} -ne 0 ]]; then \
 			echo "$(PREFIX_STEP_NEGATIVE)ISO Download failed" >&2; \
 			rm -f ./isos/$(BOX_ARCH)/$(SOURCE_ISO_NAME) &> /dev/null; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -34,20 +34,20 @@ Variables (default value):
                               - Minimal-AMI
                               - Minimal-Cloud-Init
   - BOX_VERSION_RELEASE     The CentOS-7 Minor Release number. Note: A
-    (7.6.1810)              corresponding template is required.
+    (7.7.1908)              corresponding template is required.
 
 endef
 
 BOX_NAMESPACE := jdeathe
 BOX_PROVIDOR := virtualbox
-BOX_ARCH_PATTERN := ^(x86_64|i386)$
+BOX_ARCH_PATTERN := ^x86_64$
 BOX_ARCH := x86_64
 
 BOX_DEBUG ?= false
 BOX_LANG ?= en_US
 BOX_OUTPUT_PATH ?= ./builds
 BOX_VARIANT ?= Minimal
-BOX_VERSION_RELEASE ?= 7.6.1810
+BOX_VERSION_RELEASE ?= 7.7.1908
 
 # UI constants
 COLOUR_NEGATIVE := \033[1;31m

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This provides the configuration and Makefile to build a [Vagrant](https://www.vagrantup.com) minimal base box using [Packer](https://www.packer.io). The base box is intended for server (terminal) use only so is restricted to a single locale (with `en_US` being the default) which allows for a smaller box size.
 
 There are templates provided for the following with `x86_64` architecture:
+- CentOS-7.7.1908
 - CentOS-7.6.1810
 - CentOS-7.5.1804
 - CentOS-7.4.1708
@@ -19,7 +20,7 @@ The build environment required is Mac OSX or GNU Linux.
 
 To build the box file you will need the following installed:
 
-- [VirtualBox](https://www.virtualbox.org) (6.0.10)
+- [VirtualBox](https://www.virtualbox.org) (6.0.12)
 - [Vagrant](https://www.vagrantup.com) (2.2.5)
 - [Packer](https://www.packer.io) (1.4.3)
 


### PR DESCRIPTION
CLOSES #53

- Fixes `download-iso` Makefile target.
- Adds support for CentOS-7.7.1908.
